### PR TITLE
Several minor improvements for speeding up generation and resolving misrenders

### DIFF
--- a/render/README.md
+++ b/render/README.md
@@ -21,8 +21,6 @@ _You can even turn the scene with a left-click and by moving the cursor._
 
 ### Front-end (rendering the dataset)
 
-> :warning: **Warning**: Puppeteer, a package we use to take screenshots of the rendered scenes, stores temporary files in /tmp that start with "puppeteer...". To avoid storing large amounts of data, we automatically delete all the puppeteer files in /tmp. If the default store location on your machine is a different one, you need to adjust the dictionary. Also, if your /tmp folder contains other puppeteer files that you would like to keep, adjust the code accordingly!
-
 To render the dataset, you have to run the above server and call the following lines in that order:
 
 ```

--- a/render/create_dataset.py
+++ b/render/create_dataset.py
@@ -164,16 +164,22 @@ def json_to_image(json, mode):
 def create_dataset(dataset_json, store_path, mode):
   for i,sample_json in enumerate(dataset_json):
     print(i)
-    while True:
-      img = json_to_image(sample_json, mode)
-      # test if all values are the same
-      im_matrix = np.array(img)
-      if not np.all(im_matrix[:,:,0] == im_matrix[0,0,0]):
+    for attempt in range(10):
+      try:
+        img = json_to_image(sample_json, mode)
+        # test if all values are the same
+        im_matrix = np.array(img)
+        if np.all(im_matrix[:,:,0] == im_matrix[0,0,0]):
+          raise RuntimeError('flat render')
         path = os.path.join(store_path, str(sample_json['class_idx']))
         if not os.path.exists(path):
           os.makedirs(path)
         img.save(path + '/' + str(i).zfill(6) + '.png', 'png')
         break
+      except Exception as e:
+        print('render failed, attempt', attempt + 1, 'of 10:', e)
+        if attempt == 9:
+          raise
 
 parser = argparse.ArgumentParser(description='PyTorch ImageNet Training')
 parser.add_argument('--mode', required=True,

--- a/render/create_dataset.py
+++ b/render/create_dataset.py
@@ -173,12 +173,6 @@ def create_dataset(dataset_json, store_path, mode):
         if not os.path.exists(path):
           os.makedirs(path)
         img.save(path + '/' + str(i).zfill(6) + '.png', 'png')
-        #clean tmp dir
-        pattern = os.path.join('/tmp', "puppeteer*")
-        for item in glob(pattern):
-          if not os.path.isdir(item):
-              continue
-          rmtree(item)
         break
 
 parser = argparse.ArgumentParser(description='PyTorch ImageNet Training')

--- a/render/create_dataset.py
+++ b/render/create_dataset.py
@@ -38,7 +38,7 @@ def create_classes_json(nr_classes, parts):
         i += 1
   return classes
 
-def create_dataset_json(samples_per_class, classes, parts, min_bg_parts, max_bg_parts, mode):
+def create_dataset_json(samples_per_class, classes, parts, min_bg_parts, max_bg_parts, mode, disable_interventions):
   dataset = []
   for c in range(len(classes)):
     current_class = classes[c]
@@ -57,7 +57,7 @@ def create_dataset_json(samples_per_class, classes, parts, min_bg_parts, max_bg_
       
       # set parts
       part_keys = list(parts.keys())
-      if mode == 'train' or mode == 'train_part_map': # randomly remove n parts from the bird to allow interventions to be in domain
+      if not disable_interventions and (mode == 'train' or mode == 'train_part_map'): # randomly remove n parts from the bird to allow interventions to be in domain
         if random.choice([0, 1]):
           nr_delete = random.randint(0, len(part_keys))
           part_keys_keep = delete_rand_items(part_keys, nr_delete)
@@ -199,6 +199,8 @@ parser.add_argument('--create_dataset_json', action='store_true',
                     help='create_datasert_json')
 parser.add_argument('--render_dataset', action='store_true',
                     help='create_datasert_json') 
+parser.add_argument('--disable_interventions', action='store_true',
+                    help='Disable train-time random part removal.')
 
 args = parser.parse_args()
 
@@ -231,7 +233,7 @@ else:
     print('classes.json loaded')
 
 if args.create_dataset_json:
-    dataset_json = create_dataset_json(args.nr_samples_per_class, classes, parts, 0, 35, args.mode)
+    dataset_json = create_dataset_json(args.nr_samples_per_class, classes, parts, 0, 35, args.mode, args.disable_interventions)
     if args.mode == 'train' or args.mode == 'test': 
         path_dataset_json = os.path.join(path, 'dataset_' + args.mode + '.json')
         with open(path_dataset_json, "w") as outfile:

--- a/render/page.html
+++ b/render/page.html
@@ -46,6 +46,26 @@
 			import { FontLoader } from './jsm/loaders/FontLoader.js';
 			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
 			import { TextGeometry } from './jsm/geometries/TextGeometry.js';
+
+			window.__FUNNYBIRDS_READY__ = false;
+
+			let initFinished = false;
+			let assetsLoadedBeforeInitFinished = false;
+
+			function markRenderReady() {
+				if (!initFinished) {
+					assetsLoadedBeforeInitFinished = true;
+					return;
+				}
+
+				// Let the browser present the completed scene before Puppeteer screenshots it.
+				requestAnimationFrame( function () {
+					requestAnimationFrame( function () {
+						render();
+						window.__FUNNYBIRDS_READY__ = true;
+					} );
+				} );
+			}
 			
 			var render_mode = <%- JSON.stringify(render_mode) %>
 
@@ -243,8 +263,30 @@
 
 
 				var loader = new GLTFLoader();
+				var pendingModelLoads = 0;
+
+				function finishModelLoad() {
+					pendingModelLoads -= 1;
+					if ( pendingModelLoads === 0 ) {
+						markRenderReady();
+					}
+				}
+
+				function loadModel( url, onLoad ) {
+					pendingModelLoads += 1;
+					loader.load( url, function ( gltf ) {
+						try {
+							onLoad( gltf );
+						} finally {
+							finishModelLoad();
+						}
+					}, undefined, function ( error ) {
+						console.warn( 'Failed to load asset:', url, error );
+						finishModelLoad();
+					} );
+				}
 				var base;
-				loader.load( 'data/XAI/bird01.glb', function ( gltf ) {
+				loadModel( 'data/XAI/bird01.glb', function ( gltf ) {
 
 					base = gltf.scene//.children[ 0 ];
 
@@ -279,7 +321,7 @@
 
 				// beak
 				var part01;
-				loader.load( 'data/XAI/beak/' + beak_model, function ( gltf ) {
+				loadModel( 'data/XAI/beak/' + beak_model, function ( gltf ) {
 
 					part01 = gltf.scene;
 
@@ -330,7 +372,7 @@
 
 				// feet01
 				var part02;
-				loader.load( 'data/XAI/foot/' + foot_model, function ( gltf ) {
+				loadModel( 'data/XAI/foot/' + foot_model, function ( gltf ) {
 
 					part02 = gltf.scene//.children[ 0 ];
 
@@ -368,7 +410,7 @@
 
 				// feet02
 				var part03;
-				loader.load( 'data/XAI/foot/' + foot_model, function ( gltf ) {
+				loadModel( 'data/XAI/foot/' + foot_model, function ( gltf ) {
 
 					part03 = gltf.scene//.children[ 0 ];
 
@@ -409,7 +451,7 @@
 
 				// eye01
 				var part04;
-				loader.load( 'data/XAI/eye/' + eye_model, function ( gltf ) {
+				loadModel( 'data/XAI/eye/' + eye_model, function ( gltf ) {
 
 					part04 = gltf.scene//.children[ 0 ];
 
@@ -464,7 +506,7 @@
 
 				// eye02
 				var part05;
-				loader.load( 'data/XAI/eye/' + eye_model, function ( gltf ) {
+				loadModel( 'data/XAI/eye/' + eye_model, function ( gltf ) {
 
 					part05 = gltf.scene//.children[ 0 ];
 
@@ -520,7 +562,7 @@
 
 				// tail
 				var part06;
-				loader.load( 'data/XAI/tail/' + tail_model, function ( gltf ) {
+				loadModel( 'data/XAI/tail/' + tail_model, function ( gltf ) {
 
 					part06 = gltf.scene//.children[ 0 ];
 
@@ -560,7 +602,7 @@
 
 				// wing01
 				var part07;
-				loader.load( 'data/XAI/wing/' + wing_model, function ( gltf ) {
+				loadModel( 'data/XAI/wing/' + wing_model, function ( gltf ) {
 
 					part07 = gltf.scene//.children[ 0 ];
 
@@ -600,7 +642,7 @@
 
 				// wing01
 				var part08;
-				loader.load( 'data/XAI/wing/' + wing_model, function ( gltf ) {
+				loadModel( 'data/XAI/wing/' + wing_model, function ( gltf ) {
 
 					part08 = gltf.scene//.children[ 0 ];
 
@@ -805,6 +847,10 @@
 
 
 				
+				initFinished = true;
+				if ( assetsLoadedBeforeInitFinished ) {
+					markRenderReady();
+				}
 				
 
 			}

--- a/render/render_interventions.py
+++ b/render/render_interventions.py
@@ -88,12 +88,6 @@ def render_interventions(dataset_json, store_path, parts, mode):
         if not np.all(im_matrix[:,:,0] == im_matrix[0,0,0]):
           print('SAVE IMAGE')
           img.save(path_sample + '/body_' + '_'.join(sorted(keep_parts)) + '.png', 'png')
-          #clean tmp dir
-          pattern = os.path.join('/tmp', "puppeteer*")
-          for item in glob(pattern):
-            if not os.path.isdir(item):
-                continue
-            rmtree(item)
           break
 
 
@@ -133,12 +127,6 @@ def render_background_interventions(dataset_json, store_path, parts, mode):
         im_matrix = np.array(img)
         if not np.all(im_matrix[:,:,0] == im_matrix[0,0,0]):
           img.save(path_sample, 'png')
-          #clean tmp dir
-          pattern = os.path.join('/tmp', "puppeteer*")
-          for item in glob(pattern):
-            if not os.path.isdir(item):
-                continue
-            rmtree(item)
           break
 
 

--- a/render/server.js
+++ b/render/server.js
@@ -10,14 +10,11 @@ var fs = require("fs");
 const puppeteer = require('puppeteer')
 const RENDER_TIMEOUT_MS = 30_000
 
-app.get('/render', async function (req, res) {
+let browserPromise
 
-    var params = '?' + req.url.split('?')[1];
-    console.log(params)
-    const renderStart = Date.now()
-    let browser
-    try {
-        browser = await puppeteer.launch( {
+function getBrowser() {
+    if (!browserPromise) {
+        browserPromise = puppeteer.launch( {
             headless: ! process.env.VISIBLE,
             args: [
                 '--use-gl=swiftshader',
@@ -25,8 +22,19 @@ app.get('/render', async function (req, res) {
                 '--enable-surface-synchronization'
             ]
         } )
+    }
+    return browserPromise
+}
 
-        const page = await browser.newPage()
+app.get('/render', async function (req, res) {
+
+    var params = '?' + req.url.split('?')[1];
+    console.log(params)
+    const renderStart = Date.now()
+    let page
+    try {
+        const browser = await getBrowser()
+        page = await browser.newPage()
 
         await page.setViewport({ width: 1256, height: 1256 })
         await page.goto('http://localhost:8081/page' + params, { waitUntil: 'domcontentloaded' })
@@ -42,8 +50,8 @@ app.get('/render', async function (req, res) {
         console.error('Render failed:', err)
         res.status(504).send('Render timed out before the scene was ready')
     } finally {
-        if (browser) {
-            await browser.close()
+        if (page) {
+            await page.close()
         }
     }
 })
@@ -97,5 +105,4 @@ var server = app.listen(8081, function () {
    var port = server.address().port
    console.log("Example app listening at http://%s:%s", host, port)
 })
-
 

--- a/render/server.js
+++ b/render/server.js
@@ -4,6 +4,7 @@ app.engine('html', require('ejs').renderFile);
 app.set('views', __dirname);
 //console.log(__dirname + '/views')
 app.set('view engine', 'html');
+app.use(express.static(__dirname + '/js/three.js-master/examples'));
 
 var fs = require("fs");
 const puppeteer = require('puppeteer')
@@ -86,8 +87,6 @@ app.get('/page', function (req, res) {
 
     console.log(beak_model)
     console.log(beak_color)
-    //res.send("<html> <head>server Response</head><body><h1> This page was render direcly from the server <p>Hello there welcome to my website</p></h1></body></html>");
-    app.use(express.static(__dirname + '/js/three.js-master/examples'));
 
     res.render('./page.html', {render_mode: render_mode, camera_distance: camera_distance, camera_pitch: camera_pitch, camera_roll: camera_roll, light_distance:light_distance, light_pitch: light_pitch, light_roll: light_roll, beak_model: beak_model, beak_color: beak_color, foot_model: foot_model, eye_model: eye_model, tail_model: tail_model, tail_color:tail_color, wing_model: wing_model, wing_color: wing_color, bg_objects: bg_objects, bg_scale_x:bg_scale_x, bg_scale_y:bg_scale_y, bg_scale_z:bg_scale_z, bg_rot_x:bg_rot_x, bg_rot_y:bg_rot_y, bg_rot_z:bg_rot_z, bg_color:bg_color, bg_radius:bg_radius, bg_pitch:bg_pitch, bg_roll:bg_roll});
 })

--- a/render/server.js
+++ b/render/server.js
@@ -7,13 +7,16 @@ app.set('view engine', 'html');
 
 var fs = require("fs");
 const puppeteer = require('puppeteer')
+const RENDER_TIMEOUT_MS = 30_000
 
-app.get('/render', function (req, res) {
+app.get('/render', async function (req, res) {
 
     var params = '?' + req.url.split('?')[1];
     console.log(params)
-    ; (async () => {
-        const browser = await puppeteer.launch( {
+    const renderStart = Date.now()
+    let browser
+    try {
+        browser = await puppeteer.launch( {
             headless: ! process.env.VISIBLE,
             args: [
                 '--use-gl=swiftshader',
@@ -21,17 +24,27 @@ app.get('/render', function (req, res) {
                 '--enable-surface-synchronization'
             ]
         } )
-        
+
         const page = await browser.newPage()
 
         await page.setViewport({ width: 1256, height: 1256 })
-        await page.goto('http://localhost:8081/page' + params)
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        x = await page.screenshot({ path: 'my_screenshot.png' , encoding:'base64'})
-        await browser.close()
+        await page.goto('http://localhost:8081/page' + params, { waitUntil: 'domcontentloaded' })
+        await page.waitForFunction(
+            'window.__FUNNYBIRDS_READY__ === true',
+            { timeout: RENDER_TIMEOUT_MS }
+        )
+        console.log('Render time: ' + (Date.now() - renderStart) + 'ms')
+        const x = await page.screenshot({ path: 'my_screenshot.png' , encoding:'base64'})
         res.end( x );
-        
-    })()
+
+    } catch (err) {
+        console.error('Render failed:', err)
+        res.status(504).send('Render timed out before the scene was ready')
+    } finally {
+        if (browser) {
+            await browser.close()
+        }
+    }
 })
 
 app.get('/page', function (req, res) {


### PR DESCRIPTION
Some minor improvements I've implemented while working with the `render` part of the repo:

- Replace static 1s screenshot timeout by an event-based trigger (screenshot when rendering is done). Reduces rendering in case it takes <1s and fixes silent errors / empty samples in case it takes >1s. 
- Use same Chromium instance in Puppeteer instead of firing up a new instance for every render. Besides a speedup, this also eliminates the need for the `/tmp` hotfix. Without this fix, which interfered when generating multiple datasets on the same node, it's now also possible to run two `create_dataset.py` runs on the same `server.js` backend.
- Additional `--disable_interventions` flag for creating datasets without interventions.
- Minor stuff: retry logic (now limited to 10 tries) now also retries in case of an Exception, some express route fixes.

Also, I've implemented some bigger speedups [here](https://github.com/pkwagner/funnybirds/tree/fast-renderer) (bringing a render down from ~2s to <100ms), but they change quite a bit of the core logic and I'm not yet confident enough that they indeed produce the exact same output.